### PR TITLE
Add Pokepaste support on team import

### DIFF
--- a/psclient/src/main/res/layout/dialog_import_team.xml
+++ b/psclient/src/main/res/layout/dialog_import_team.xml
@@ -40,20 +40,40 @@
                 android:layout_height="wrap_content"
                 android:text="Pastebin"/>
 
+        <RadioButton
+                android:id="@+id/pokepaste_radio"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Pokepaste"/>
+
     </RadioGroup>
 
     <EditText
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:visibility="gone"
-            android:inputType="textNoSuggestions"
-            android:ems="10"
-            android:hint="Url or key"
-            android:lines="1"
-            android:id="@+id/url_input"
-            app:layout_constraintBottom_toBottomOf="@+id/radioGroup"
-            app:layout_constraintStart_toEndOf="@+id/radioGroup"
-            android:layout_marginStart="16dp"/>
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="invisible"
+        android:inputType="textNoSuggestions"
+        android:ems="10"
+        android:hint="Enter URL or key"
+        android:lines="1"
+        android:id="@+id/pastebin_url_input"
+        app:layout_constraintBottom_toTopOf="@+id/pokepaste_url_input"
+        app:layout_constraintLeft_toLeftOf="@+id/pokepaste_url_input"
+        app:layout_constraintRight_toRightOf="@+id/pokepaste_url_input"
+        android:layout_marginStart="16dp"/>
+
+    <EditText
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="invisible"
+        android:inputType="textNoSuggestions"
+        android:ems="10"
+        android:hint="Enter Pokepaste URL"
+        android:lines="1"
+        android:id="@+id/pokepaste_url_input"
+        app:layout_constraintBottom_toBottomOf="@+id/radioGroup"
+        app:layout_constraintStart_toEndOf="@+id/radioGroup"
+        android:layout_marginStart="16dp"/>
 
     <Button
             android:text="Import"


### PR DESCRIPTION
## Overview

Hello :smile: I use Pokepaste a lot when copying teams, so I thought it would be nice to add support here too.

I added another radio button to the import fragment, just to keep it separate from the current pastebin implementation.


## Screenshots
#### Selecting Pokepaste radio button
<img src="https://user-images.githubusercontent.com/660302/87550218-c7346200-c6e9-11ea-8fcf-77213e623dab.png" alt="drawing" width="200"/>

#### Selecting existing Pastebin radio button
Note that the text box for each type of import lines up with the respective radio button 
<img src="https://user-images.githubusercontent.com/660302/87550223-c8fe2580-c6e9-11ea-8c8a-f408bd7a54fa.png" alt="drawing" width="200"/>

#### Error if entered text does not match expected regex
<img src="https://user-images.githubusercontent.com/660302/87550226-c996bc00-c6e9-11ea-8a27-c8048b2e0256.png" alt="drawing" width="200"/>


## Other Notes

- I changed the default visibility of the text boxes from `GONE` to `INVISIBLE`. This allows the text boxes to stay in the correct place (as there are currently two stacked on top of eachother - one for pastebin url, and one for pokepaste url)
- I chose not to add unit or instrumented tests as there don't currently appear to be any, and I didn't want to introduce too big a changeset
- I'm not super familiar with Kotlin yet, so if something doesn't look right then please let me know
- For the layout, I just chose to extend what was already there, but if you want me to change the layout of the things I added etc, please let me know

Thanks!